### PR TITLE
fix: Add missing langchain-community dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pymongo
 motor
 langchain
 langchain-google-genai
+langchain-community
 firebase-admin
 python-dotenv
 pydantic


### PR DESCRIPTION
This commit adds `langchain-community` to the `requirements.txt` file.

The `langchain` library recently moved many of its third-party integrations, including the one for MongoDB Atlas Vector Search, to the `langchain-community` package. This was causing a `ModuleNotFoundError` during deployment.

Adding this package to the requirements ensures that all necessary dependencies are installed in the deployment environment, resolving the startup error.