### PR TITLE
fix: Add python-multipart for file uploads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pydantic
 PyPDF2
 tiktoken
 google-generativeai
+python-multipart


### PR DESCRIPTION
This commit adds `python-multipart` to the `requirements.txt` file.

FastAPI requires this package to parse multipart/form-data, which is used for handling file uploads. This dependency was missing, causing a `RuntimeError` when the application started up on Render.

Adding this package to the requirements resolves the final deployment error.