### PR TITLE
feat: Add basic HTML/JS frontend example

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Notes & PDF Chat API</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <header>
+        <h1>Notes & PDF Chat API Frontend</h1>
+        <p>A simple frontend to demonstrate the API's capabilities.</p>
+    </header>
+
+    <main class="container">
+        <!-- Authentication Section -->
+        <section class="card">
+            <h2>1. Authentication</h2>
+            <p>
+                To use the API, you must provide a valid Firebase ID Token.
+                Since this is a simple demo, you'll need to get this token from your own Firebase client application.
+            </p>
+            <textarea id="firebase-token" placeholder="Paste your Firebase ID Token here..." rows="4"></textarea>
+            <button id="save-token-btn">Save Token</button>
+            <p id="auth-status" class="status-message">Status: No Token Set</p>
+        </section>
+
+        <!-- Notes Section -->
+        <section class="card">
+            <h2>2. Notes CRUD</h2>
+            <form id="note-form">
+                <input type="text" id="note-title" placeholder="Note Title" required>
+                <textarea id="note-desc" placeholder="Note Description" rows="3" required></textarea>
+                <label>
+                    <input type="checkbox" id="note-important"> Important
+                </label>
+                <button type="submit">Add Note</button>
+            </form>
+            <hr>
+            <h3>Your Notes</h3>
+            <div id="notes-list">
+                <p>Notes will appear here after you add them...</p>
+            </div>
+        </section>
+
+        <!-- RAG PDF Chat Section -->
+        <section class="card">
+            <h2>3. PDF Chat (RAG)</h2>
+
+            <!-- PDF Upload -->
+            <div class="sub-section">
+                <h3>Upload a PDF</h3>
+                <form id="upload-form">
+                    <input type="file" id="pdf-file" accept=".pdf" required>
+                    <button type="submit">Upload & Process PDF</button>
+                </form>
+                <div id="upload-status" class="status-message"></div>
+                <p>Current File ID for Chat: <strong id="current-file-id">None</strong></p>
+            </div>
+
+            <!-- Chat Interface -->
+            <div class="sub-section">
+                <h3>Chat with your PDF</h3>
+                <div id="chat-container">
+                    <div id="chat-box">
+                        <p class="bot-message">Please upload a PDF to begin chatting.</p>
+                    </div>
+                    <form id="chat-form">
+                        <input type="text" id="chat-input" placeholder="Ask a question about your PDF..." disabled>
+                        <button type="submit" id="send-chat-btn" disabled>Send</button>
+                    </form>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="/static/script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,247 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // --- Globals ---
+    const API_URL = window.location.origin;
+    let FIREBASE_ID_TOKEN = localStorage.getItem('firebaseIdToken') || '';
+    let CURRENT_FILE_ID = '';
+    let CHAT_HISTORY = [];
+
+    // --- DOM Elements ---
+    const tokenTextarea = document.getElementById('firebase-token');
+    const saveTokenBtn = document.getElementById('save-token-btn');
+    const authStatus = document.getElementById('auth-status');
+
+    const noteForm = document.getElementById('note-form');
+    const noteTitleInput = document.getElementById('note-title');
+    const noteDescInput = document.getElementById('note-desc');
+    const noteImportantInput = document.getElementById('note-important');
+    const notesList = document.getElementById('notes-list');
+
+    const uploadForm = document.getElementById('upload-form');
+    const pdfFileInput = document.getElementById('pdf-file');
+    const uploadStatus = document.getElementById('upload-status');
+    const currentFileIdSpan = document.getElementById('current-file-id');
+
+    const chatForm = document.getElementById('chat-form');
+    const chatInput = document.getElementById('chat-input');
+    const sendChatBtn = document.getElementById('send-chat-btn');
+    const chatBox = document.getElementById('chat-box');
+
+    // --- Helper Functions ---
+    const getAuthHeaders = () => {
+        if (!FIREBASE_ID_TOKEN) {
+            alert('Firebase ID Token is not set. Please paste it in the Authentication section.');
+            return null;
+        }
+        return {
+            'Authorization': `Bearer ${FIREBASE_ID_TOKEN}`
+        };
+    };
+
+    const addMessageToChatbox = (sender, message) => {
+        const messageElement = document.createElement('p');
+        messageElement.className = sender === 'user' ? 'user-message' : 'bot-message';
+        messageElement.textContent = message;
+        chatBox.appendChild(messageElement);
+        chatBox.scrollTop = chatBox.scrollHeight; // Scroll to bottom
+    };
+
+    // --- Authentication ---
+    const updateAuthStatus = () => {
+        if (FIREBASE_ID_TOKEN) {
+            authStatus.textContent = 'Status: Token is Set.';
+            authStatus.style.color = 'green';
+            tokenTextarea.value = FIREBASE_ID_TOKEN;
+        } else {
+            authStatus.textContent = 'Status: No Token Set';
+            authStatus.style.color = 'red';
+        }
+    };
+
+    saveTokenBtn.addEventListener('click', () => {
+        FIREBASE_ID_TOKEN = tokenTextarea.value.trim();
+        if (FIREBASE_ID_TOKEN) {
+            localStorage.setItem('firebaseIdToken', FIREBASE_ID_TOKEN);
+            updateAuthStatus();
+            fetchNotes(); // Fetch notes with the new token
+        } else {
+            alert('Please paste a token before saving.');
+        }
+    });
+
+    // --- Notes ---
+    const fetchNotes = async () => {
+        const headers = getAuthHeaders();
+        if (!headers) return;
+
+        try {
+            const response = await fetch(`${API_URL}/api/notes`, { headers });
+            if (!response.ok) {
+                throw new Error(`Failed to fetch notes. Status: ${response.status}`);
+            }
+            const notes = await response.json();
+            renderNotes(notes);
+        } catch (error) {
+            console.error('Error fetching notes:', error);
+            notesList.innerHTML = `<p class="error">Error fetching notes. Check token or console.</p>`;
+        }
+    };
+
+    const renderNotes = (notes) => {
+        notesList.innerHTML = '';
+        if (notes.length === 0) {
+            notesList.innerHTML = '<p>No notes found. Add one above!</p>';
+            return;
+        }
+        notes.forEach(note => {
+            const noteEl = document.createElement('div');
+            noteEl.className = 'note-item';
+            noteEl.innerHTML = `
+                <div>
+                    <strong>${note.title}</strong> ${note.important ? ' (Important)' : ''}
+                    <p>${note.desc}</p>
+                </div>
+                <button data-id="${note.id}" class="delete-btn">Delete</button>
+            `;
+            notesList.appendChild(noteEl);
+        });
+    };
+
+    noteForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const headers = getAuthHeaders();
+        if (!headers) return;
+
+        const noteData = {
+            title: noteTitleInput.value,
+            desc: noteDescInput.value,
+            important: noteImportantInput.checked
+        };
+
+        try {
+            const response = await fetch(`${API_URL}/api/notes`, {
+                method: 'POST',
+                headers: { ...headers, 'Content-Type': 'application/json' },
+                body: JSON.stringify(noteData)
+            });
+            if (!response.ok) {
+                throw new Error('Failed to create note.');
+            }
+            noteForm.reset();
+            fetchNotes(); // Refresh list
+        } catch (error) {
+            console.error('Error creating note:', error);
+            alert('Failed to create note.');
+        }
+    });
+
+    notesList.addEventListener('click', async (e) => {
+        if (e.target.classList.contains('delete-btn')) {
+            const noteId = e.target.dataset.id;
+            const headers = getAuthHeaders();
+            if (!headers) return;
+
+            if (confirm('Are you sure you want to delete this note?')) {
+                try {
+                    const response = await fetch(`${API_URL}/api/notes/${noteId}`, {
+                        method: 'DELETE',
+                        headers
+                    });
+                    if (!response.ok) {
+                        throw new Error('Failed to delete note.');
+                    }
+                    fetchNotes(); // Refresh list
+                } catch (error) {
+                    console.error('Error deleting note:', error);
+                    alert('Failed to delete note.');
+                }
+            }
+        }
+    });
+
+    // --- RAG PDF Chat ---
+    uploadForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const headers = getAuthHeaders();
+        if (!headers) return;
+        if (pdfFileInput.files.length === 0) {
+            alert('Please select a PDF file to upload.');
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('file', pdfFileInput.files[0]);
+
+        uploadStatus.textContent = 'Uploading and processing...';
+        uploadStatus.style.color = 'orange';
+
+        try {
+            const response = await fetch(`${API_URL}/api/rag/upload`, {
+                method: 'POST',
+                headers,
+                body: formData
+            });
+
+            const result = await response.json();
+
+            if (!response.ok) {
+                throw new Error(result.detail || 'Failed to upload PDF.');
+            }
+
+            CURRENT_FILE_ID = result.file_id;
+            CHAT_HISTORY = []; // Reset history for new file
+            currentFileIdSpan.textContent = CURRENT_FILE_ID;
+            uploadStatus.textContent = `Successfully processed: ${result.filename}`;
+            uploadStatus.style.color = 'green';
+            chatInput.disabled = false;
+            sendChatBtn.disabled = false;
+            chatBox.innerHTML = '<p class="bot-message">You can now chat with your PDF.</p>';
+
+        } catch (error) {
+            console.error('Error uploading PDF:', error);
+            uploadStatus.textContent = `Error: ${error.message}`;
+            uploadStatus.style.color = 'red';
+        }
+    });
+
+    chatForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const question = chatInput.value.trim();
+        if (!question || !CURRENT_FILE_ID) return;
+
+        const headers = getAuthHeaders();
+        if (!headers) return;
+
+        addMessageToChatbox('user', question);
+        chatInput.value = '';
+        sendChatBtn.disabled = true; // Disable while waiting for response
+
+        try {
+            const response = await fetch(`${API_URL}/api/rag/chat/${CURRENT_FILE_ID}`, {
+                method: 'POST',
+                headers: { ...headers, 'Content-Type': 'application/json' },
+                body: JSON.stringify({ question, chat_history: CHAT_HISTORY })
+            });
+
+            const result = await response.json();
+            if (!response.ok) {
+                throw new Error(result.detail || 'Failed to get chat response.');
+            }
+
+            CHAT_HISTORY = result.chat_history;
+            addMessageToChatbox('bot', result.answer);
+
+        } catch (error) {
+            console.error('Chat error:', error);
+            addMessageToChatbox('bot', `Error: ${error.message}`);
+        } finally {
+            sendChatBtn.disabled = false; // Re-enable button
+        }
+    });
+
+
+    // --- Initial Load ---
+    updateAuthStatus();
+    if (FIREBASE_ID_TOKEN) {
+        fetchNotes();
+    }
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,172 @@
+/* --- General & Variables --- */
+:root {
+    --bg-color: #1a1a1a;
+    --surface-color: #2a2a2a;
+    --primary-color: #007bff;
+    --text-color: #e0e0e0;
+    --border-color: #444;
+    --error-color: #ff4d4d;
+    --success-color: #4caf50;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    padding: 20px;
+    line-height: 1.6;
+}
+
+/* --- Layout & Structure --- */
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 30px;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 20px;
+}
+
+header h1 {
+    color: var(--primary-color);
+}
+
+.card, .sub-section {
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 20px;
+}
+
+.sub-section {
+    margin-top: 20px;
+}
+
+hr {
+    border: none;
+    border-top: 1px solid var(--border-color);
+    margin: 20px 0;
+}
+
+/* --- Forms & Inputs --- */
+input[type="text"],
+textarea {
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 10px;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    box-sizing: border-box; /* Important for width calculation */
+}
+
+input[type="file"] {
+    margin-bottom: 10px;
+}
+
+button {
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    padding: 10px 15px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+button:disabled {
+    background-color: #555;
+    cursor: not-allowed;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+}
+
+label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+/* --- Specific Sections --- */
+#auth-status {
+    font-weight: bold;
+}
+
+.status-message {
+    margin-top: 10px;
+    font-weight: bold;
+}
+
+.note-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.note-item:last-child {
+    border-bottom: none;
+}
+
+.note-item p {
+    margin: 5px 0 0 0;
+    color: #ccc;
+}
+
+.delete-btn {
+    background-color: var(--error-color);
+}
+.delete-btn:hover {
+    background-color: #cc0000;
+}
+
+/* --- Chat Interface --- */
+#chat-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#chat-box {
+    height: 250px;
+    overflow-y: auto;
+    border: 1px solid var(--border-color);
+    padding: 10px;
+    border-radius: 4px;
+    background-color: var(--bg-color);
+}
+
+#chat-form {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+}
+
+.user-message {
+    text-align: right;
+    color: #a0c4ff;
+    margin: 5px 0;
+}
+
+.bot-message {
+    text-align: left;
+    color: #c1e9c1;
+    margin: 5px 0;
+}


### PR DESCRIPTION
This commit adds a simple, single-page frontend built with vanilla HTML, CSS, and JavaScript. This serves as a demonstration and a starting point for interacting with the deployed backend API.

This approach was taken as a workaround for the persistent `npm` errors in the development environment that blocked the creation of a full React application.

Key additions:
- `public/index.html`: The main UI structure.
- `public/style.css`: Basic dark-mode styling for the interface.
- `public/script.js`: Client-side logic for API interaction (auth, notes, PDF chat).
- Updated `main.py` to serve the static files from the `public/` directory.